### PR TITLE
Defined an column that clickable for firing select single item event

### DIFF
--- a/src/main/java/io/awesome/ui/annotations/GridColumn.java
+++ b/src/main/java/io/awesome/ui/annotations/GridColumn.java
@@ -23,4 +23,6 @@ public @interface GridColumn {
   boolean frozen() default false;
 
   ColumnTextAlign textAlign() default ColumnTextAlign.START;
+
+  boolean selectable() default false;
 }

--- a/src/main/java/io/awesome/ui/components/GridComponent.java
+++ b/src/main/java/io/awesome/ui/components/GridComponent.java
@@ -1,19 +1,19 @@
 package io.awesome.ui.components;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.GridVariant;
-import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.component.icon.Icon;
-import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import io.awesome.enums.IAttributeEnum;
 import io.awesome.ui.annotations.GridColumn;
-import io.awesome.ui.components.common.EnumBadge;
+import io.awesome.ui.components.grid.column.Badge;
+import io.awesome.ui.components.grid.column.Checkbox;
+import io.awesome.ui.util.UIUtil;
 import io.awesome.ui.views.Callback;
 import io.awesome.ui.views.SelectCallback;
 import io.awesome.util.SystemUtil;
@@ -59,48 +59,12 @@ public class GridComponent<L> extends Grid<L> implements IEventListener, ISelect
     for (Field field : beanType.getDeclaredFields()) {
       if (field.isAnnotationPresent(GridColumn.class)) {
         GridColumn annotation = field.getAnnotation(GridColumn.class);
-        ComponentRenderer<Component, L> componentRenderer =
-            new ComponentRenderer<>(
-                t -> {
-                  Object value = SystemUtil.getInstance().invokeGetter(t, field.getName());
-                  if (value == null) {
-                    return new Span();
-                  }
-                  if (value instanceof IAttributeEnum) {
-                    //return new Span(((IAttributeEnum<?, ?>) value).getLabel());
-                      return new EnumBadge((IAttributeEnum<?, ?>) value);
-                  }
-                  if (value instanceof Boolean) {
-                    Div wrapper = new Div();
-                    wrapper.setWidthFull();
-                    Icon icon;
-                    if (value.equals(Boolean.FALSE)) {
-                      icon = new Icon(VaadinIcon.CLOSE_CIRCLE);
-                      icon.setColor("red");
-                    } else {
-                      icon = new Icon(VaadinIcon.CHEVRON_CIRCLE_DOWN);
-                      icon.setColor("green");
-                    }
-                    icon.setSize("15px");
-                    wrapper.add(icon);
-                    return wrapper;
-                  }
-                  if (value instanceof LocalDate) {
-                    String dateFormat =
-                        ((LocalDate) value).format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
-                    return new Span(dateFormat);
-                  }
-                  if (value instanceof LocalTime) {
-                    String timeFormat =
-                        ((LocalTime) value).format(DateTimeFormatter.ofPattern("HH:mm"));
-                    return new Span(timeFormat);
-                  }
-                  if (value instanceof Component) {
-                    return (Component) value;
-                  }
-                  return new Span(String.valueOf(value));
-                });
-
+        ComponentRenderer<Component, L> componentRenderer;
+        if (annotation.selectable()) {
+          componentRenderer = buildSelectComponentRender(field);
+        } else {
+          componentRenderer = buildComponentRender(field);
+        }
         addColumn(componentRenderer)
             .setKey(field.getName())
             .setAutoWidth(annotation.autoWidth())
@@ -117,6 +81,68 @@ public class GridComponent<L> extends Grid<L> implements IEventListener, ISelect
         GridVariant.LUMO_NO_BORDER,
         GridVariant.LUMO_ROW_STRIPES,
         GridVariant.LUMO_WRAP_CELL_CONTENT);
+  }
+
+  private ComponentRenderer<Component, L> buildComponentRender(Field field) {
+    ComponentRenderer<Component, L> componentRenderer =
+        new ComponentRenderer<>(
+            t -> {
+              Object value = SystemUtil.getInstance().invokeGetter(t, field.getName());
+              if (value == null) {
+                return new Span();
+              }
+              if (value instanceof IAttributeEnum) {
+                return new Badge((IAttributeEnum<?, ?>) value);
+              }
+              if (value instanceof Boolean) {
+                return new Checkbox((Boolean) value);
+              }
+              if (value instanceof LocalDate) {
+                String dateFormat =
+                    ((LocalDate) value).format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
+                return new Span(dateFormat);
+              }
+              if (value instanceof LocalTime) {
+                String timeFormat =
+                    ((LocalTime) value).format(DateTimeFormatter.ofPattern("HH:mm"));
+                return new Span(timeFormat);
+              }
+              if (value instanceof Component) {
+                return (Component) value;
+              }
+              return new Span(String.valueOf(value));
+            });
+    return componentRenderer;
+  }
+
+  private ComponentRenderer<Component, L> buildSelectComponentRender(Field field) {
+    ComponentRenderer<Component, L> componentRenderer =
+        new ComponentRenderer<>(
+            t -> {
+              Object value = SystemUtil.getInstance().invokeGetter(t, field.getName());
+              Button button = new Button();
+              if (value == null) {
+                button.setText("");
+              } else if (value instanceof IAttributeEnum) {
+                button.setText(((IAttributeEnum<?, ?>) value).getLabel());
+              } else if (value instanceof LocalDate) {
+                String dateFormat =
+                    ((LocalDate) value).format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
+                button.setText(dateFormat);
+              } else if (value instanceof LocalTime) {
+                String timeFormat =
+                    ((LocalTime) value).format(DateTimeFormatter.ofPattern("HH:mm"));
+                button.setText(timeFormat);
+              } else if (value instanceof Component) {
+                return (Component) value;
+              } else {
+                button.setText(String.valueOf(value));
+              }
+              button.addClickListener(b -> selectCallback.trigger(t));
+              UIUtil.setTheme("tertiary", button);
+              return button;
+            });
+    return componentRenderer;
   }
 
   @Override

--- a/src/main/java/io/awesome/ui/components/button/CancelButton.java
+++ b/src/main/java/io/awesome/ui/components/button/CancelButton.java
@@ -1,6 +1,7 @@
 package io.awesome.ui.components.button;
 
 import com.vaadin.flow.component.button.Button;
+import io.awesome.exception.SystemException;
 import io.awesome.ui.components.AbstractForm;
 import io.awesome.ui.components.IFormAction;
 import io.awesome.config.Constants;
@@ -24,6 +25,7 @@ public class CancelButton implements ActionButton {
             handler.execute(form.getEntity());
           } catch (Exception e) {
             logger.error(Constants.EXCEPTION_PREFIX, e);
+            throw new SystemException(e.getMessage(), e.getCause());
           }
         });
   }

--- a/src/main/java/io/awesome/ui/components/button/ConfirmButton.java
+++ b/src/main/java/io/awesome/ui/components/button/ConfirmButton.java
@@ -1,0 +1,67 @@
+package io.awesome.ui.components.button;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.orderedlayout.FlexComponent;
+import com.vaadin.flow.component.orderedlayout.FlexLayout;
+import io.awesome.exception.SystemException;
+import io.awesome.ui.components.AbstractForm;
+import io.awesome.ui.components.IFormAction;
+import io.awesome.ui.components.dialog.ConfirmDialog;
+import io.awesome.ui.util.UIUtil;
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class ConfirmButton implements ActionButton {
+    public static final String TYPE_CONFIRM = "Confirm";
+    private final Button button;
+    private final ConfirmDialog dialog;
+
+    public ConfirmButton(String label, String message, String... classNames) {
+        button = UIUtil.createErrorPrimaryButton(label);
+        dialog = new ConfirmDialog(label + " confirmation", message, classNames);
+        buildButton(classNames);
+    }
+
+    private void buildButton(String... classNames) {
+        List<String> classButton = new ArrayList<>(List.of("control-button"));
+        if (classNames != null && classNames.length > 0) {
+            Arrays.stream(classNames).forEach(classButton::add);
+        } else {
+            classButton.add("green-button");
+        }
+        this.button.addClassNames(classButton.toArray(new String[0]));
+        this.button.setWidthFull();
+        this.button.addClickListener(
+                (event) -> {
+                    this.dialog.open();
+                });
+        FlexLayout wrapper = new FlexLayout(this.button);
+        wrapper.setWidthFull();
+        wrapper.setJustifyContentMode(FlexComponent.JustifyContentMode.END);
+    }
+
+    public void addActionHandler(IFormAction handler, AbstractForm form, Logger logger) {
+        this.dialog.setConfirmListener(
+                (buttonClickEvent) -> {
+                    try {
+                        handler.execute(form.getEntity());
+                        this.dialog.close();
+                    } catch (Exception e) {
+                        logger.error("RUNTIME_EXCEPTION >>", e);
+                        throw new SystemException(e.getMessage(), e.getCause());
+                    }
+                });
+    }
+
+    public Button getButton() {
+        return this.button;
+    }
+
+    public String getType() {
+        return TYPE_CONFIRM;
+    }
+}
+

--- a/src/main/java/io/awesome/ui/components/button/ConfirmButton.java
+++ b/src/main/java/io/awesome/ui/components/button/ConfirmButton.java
@@ -15,53 +15,52 @@ import java.util.Arrays;
 import java.util.List;
 
 public class ConfirmButton implements ActionButton {
-    public static final String TYPE_CONFIRM = "Confirm";
-    private final Button button;
-    private final ConfirmDialog dialog;
+  public static final String TYPE_CONFIRM = "Confirm";
+  private final Button button;
+  private final ConfirmDialog dialog;
 
-    public ConfirmButton(String label, String message, String... classNames) {
-        button = UIUtil.createErrorPrimaryButton(label);
-        dialog = new ConfirmDialog(label + " confirmation", message, classNames);
-        buildButton(classNames);
-    }
+  public ConfirmButton(String label, String message, String... classNames) {
+    button = UIUtil.createErrorPrimaryButton(label);
+    dialog = new ConfirmDialog(label + " confirmation", message, classNames);
+    buildButton(classNames);
+  }
 
-    private void buildButton(String... classNames) {
-        List<String> classButton = new ArrayList<>(List.of("control-button"));
-        if (classNames != null && classNames.length > 0) {
-            Arrays.stream(classNames).forEach(classButton::add);
-        } else {
-            classButton.add("green-button");
-        }
-        this.button.addClassNames(classButton.toArray(new String[0]));
-        this.button.setWidthFull();
-        this.button.addClickListener(
-                (event) -> {
-                    this.dialog.open();
-                });
-        FlexLayout wrapper = new FlexLayout(this.button);
-        wrapper.setWidthFull();
-        wrapper.setJustifyContentMode(FlexComponent.JustifyContentMode.END);
+  private void buildButton(String... classNames) {
+    List<String> classButton = new ArrayList<>(List.of("control-button"));
+    if (classNames != null && classNames.length > 0) {
+      Arrays.stream(classNames).forEach(classButton::add);
+    } else {
+      classButton.add("green-button");
     }
+    this.button.addClassNames(classButton.toArray(new String[0]));
+    this.button.setWidthFull();
+    this.button.addClickListener(
+        (event) -> {
+          this.dialog.open();
+        });
+    FlexLayout wrapper = new FlexLayout(this.button);
+    wrapper.setWidthFull();
+    wrapper.setJustifyContentMode(FlexComponent.JustifyContentMode.END);
+  }
 
-    public void addActionHandler(IFormAction handler, AbstractForm form, Logger logger) {
-        this.dialog.setConfirmListener(
-                (buttonClickEvent) -> {
-                    try {
-                        handler.execute(form.getEntity());
-                        this.dialog.close();
-                    } catch (Exception e) {
-                        logger.error("RUNTIME_EXCEPTION >>", e);
-                        throw new SystemException(e.getMessage(), e.getCause());
-                    }
-                });
-    }
+  public void addActionHandler(IFormAction handler, AbstractForm form, Logger logger) {
+    this.dialog.setConfirmListener(
+        (buttonClickEvent) -> {
+          try {
+            handler.execute(form.getEntity());
+            this.dialog.close();
+          } catch (Exception e) {
+            logger.error("RUNTIME_EXCEPTION >>", e);
+            throw new SystemException(e.getMessage(), e.getCause());
+          }
+        });
+  }
 
-    public Button getButton() {
-        return this.button;
-    }
+  public Button getButton() {
+    return this.button;
+  }
 
-    public String getType() {
-        return TYPE_CONFIRM;
-    }
+  public String getType() {
+    return TYPE_CONFIRM;
+  }
 }
-

--- a/src/main/java/io/awesome/ui/components/button/DeleteButton.java
+++ b/src/main/java/io/awesome/ui/components/button/DeleteButton.java
@@ -1,69 +1,11 @@
 package io.awesome.ui.components.button;
 
-import com.vaadin.flow.component.button.Button;
-import com.vaadin.flow.component.dialog.Dialog;
-import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.component.orderedlayout.FlexComponent;
-import com.vaadin.flow.component.orderedlayout.FlexLayout;
-import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
-import io.awesome.config.Constants;
-import io.awesome.ui.components.AbstractForm;
-import io.awesome.ui.components.IFormAction;
-import io.awesome.ui.util.UIUtil;
-import org.slf4j.Logger;
-
-public class DeleteButton implements ActionButton {
+public class DeleteButton extends ConfirmButton {
   public static final String DELETE_BTN_LABEL = "Delete";
   public static final String TYPE_DELETE = "Delete";
-  Button button = UIUtil.createErrorPrimaryButton(DELETE_BTN_LABEL);
-  Button confirmButton = UIUtil.createErrorPrimaryButton("Confirm");
-  Dialog dialog = new Dialog();
 
   public DeleteButton() {
-    button.addClassNames("control-button", "red-button");
-    button.setWidthFull();
-    button.addClickListener(
-        event -> {
-          dialog.removeAll();
-          dialog.setWidth("400px");
-          dialog.setCloseOnOutsideClick(false);
-
-          Span message = new Span();
-          message.setText(
-              "Are you sure you want to " + this.button.getText().toLowerCase() + " this record ?");
-          message.setSizeFull();
-
-          confirmButton.addClassNames("control-button", "red-button");
-          Button cancelButton = new Button("Cancel", e -> dialog.close());
-          cancelButton.addClassNames("control-button", "blue-button");
-          HorizontalLayout flexLayout = new HorizontalLayout(confirmButton, cancelButton);
-          flexLayout.setWidthFull();
-          flexLayout.setMargin(true);
-          flexLayout.setPadding(true);
-          dialog.add(message, flexLayout);
-          dialog.open();
-        });
-    FlexLayout wrapper = new FlexLayout(button);
-    wrapper.setWidthFull();
-    wrapper.setJustifyContentMode(FlexComponent.JustifyContentMode.END);
-  }
-
-  @Override
-  public void addActionHandler(IFormAction handler, AbstractForm form, Logger logger) {
-    this.confirmButton.addClickListener(
-        buttonClickEvent -> {
-          try {
-            handler.execute(form.getEntity());
-            dialog.close();
-          } catch (Exception e) {
-            logger.error(Constants.EXCEPTION_PREFIX, e);
-          }
-        });
-  }
-
-  @Override
-  public Button getButton() {
-    return button;
+    super(DELETE_BTN_LABEL, "Are you sure you want to delete this record ?", "red-button");
   }
 
   @Override

--- a/src/main/java/io/awesome/ui/components/button/SaveButton.java
+++ b/src/main/java/io/awesome/ui/components/button/SaveButton.java
@@ -1,6 +1,7 @@
 package io.awesome.ui.components.button;
 
 import com.vaadin.flow.component.button.Button;
+import io.awesome.exception.SystemException;
 import io.awesome.exception.ValidateException;
 import io.awesome.ui.components.AbstractForm;
 import io.awesome.ui.components.IFormAction;
@@ -33,6 +34,7 @@ public class SaveButton implements ActionButton {
             logger.error(Constants.VALIDATE_EXCEPTION_PREFIX, e);
           } catch (Exception e) {
             logger.error(Constants.EXCEPTION_PREFIX, e);
+            throw new SystemException(e.getMessage(), e.getCause());
           }
         });
   }

--- a/src/main/java/io/awesome/ui/components/dialog/ConfirmDialog.java
+++ b/src/main/java/io/awesome/ui/components/dialog/ConfirmDialog.java
@@ -16,110 +16,120 @@ import java.util.List;
 
 public class ConfirmDialog extends Dialog {
 
-    private String title = "";
-    private String message = "";
-    private HorizontalLayout header;
-    private VerticalLayout body;
-    private HorizontalLayout footer;
-    private Button confirmButton;
+  private String title = "";
+  private String message = "";
+  private HorizontalLayout header;
+  private VerticalLayout body;
+  private HorizontalLayout footer;
+  private Button confirmButton;
 
-    public ConfirmDialog(String... classNames) {
-        VerticalLayout dialogLayout = createDialogLayout(classNames);
-        this.add(dialogLayout);
+  public ConfirmDialog(String... classNames) {
+    VerticalLayout dialogLayout = createDialogLayout(classNames);
+    this.add(dialogLayout);
+  }
+
+  public ConfirmDialog(String title, String message, String... classNames) {
+    this(classNames);
+    this.setTitle(title);
+    this.setMessage(message);
+  }
+
+  private VerticalLayout createDialogLayout(String... classNames) {
+    this.header = buildHeaderLayout();
+    this.body = buildBodyLayout();
+    this.footer = buildFooterLayout(classNames);
+
+    VerticalLayout dialogLayout = new VerticalLayout(header, body, footer);
+    dialogLayout.setPadding(false);
+    dialogLayout.setAlignItems(FlexComponent.Alignment.STRETCH);
+    dialogLayout.getStyle().set("width", "600px").set("max-width", "100%");
+
+    return dialogLayout;
+  }
+
+  private HorizontalLayout buildHeaderLayout() {
+    H2 title = new H2(this.title);
+    title.setClassName("title");
+    title.getElement().setAttribute("title", this.title);
+    title
+        .getStyle()
+        .set("margin", "-5px 0 0 15px")
+        .set("font-size", "22px")
+        .set("font-weight", "bold");
+    HorizontalLayout headerLayout = new HorizontalLayout(title);
+    headerLayout.setJustifyContentMode(FlexComponent.JustifyContentMode.START);
+    return headerLayout;
+  }
+
+  private HorizontalLayout buildFooterLayout(String... classNames) {
+    confirmButton = new Button("Confirm");
+    List<String> classButton = new ArrayList<>(List.of("control-button"));
+    if (classNames != null && classNames.length > 0) {
+      Arrays.stream(classNames).forEach(classButton::add);
+    } else {
+      classButton.add("green-button");
     }
+    confirmButton.addClassNames(classButton.toArray(new String[0]));
+    Button cancelButton = new Button("Cancel", e -> this.close());
+    cancelButton.addClassNames("control-button", "blue-button");
 
-    public ConfirmDialog(String title, String message, String... classNames) {
-        this(classNames);
-        this.setTitle(title);
-        this.setMessage(message);
-    }
+    HorizontalLayout footerLayout = new HorizontalLayout(confirmButton, cancelButton);
+    footerLayout.setJustifyContentMode(FlexComponent.JustifyContentMode.END);
+    footerLayout.getStyle().set("margin", "20px 0 -15px 0");
+    return footerLayout;
+  }
 
-    private VerticalLayout createDialogLayout(String... classNames) {
-        this.header = buildHeaderLayout();
-        this.body = buildBodyLayout();
-        this.footer = buildFooterLayout(classNames);
+  private VerticalLayout buildBodyLayout() {
+    Span messageField = new Span(this.message);
+    messageField.getElement().setAttribute("message", message);
+    VerticalLayout bodyLayout = new VerticalLayout(messageField);
+    bodyLayout.setSpacing(false);
+    bodyLayout.setPadding(false);
+    bodyLayout.setAlignItems(FlexComponent.Alignment.STRETCH);
+    return bodyLayout;
+  }
 
-        VerticalLayout dialogLayout = new VerticalLayout(header, body,
-                footer);
-        dialogLayout.setPadding(false);
-        dialogLayout.setAlignItems(FlexComponent.Alignment.STRETCH);
-        dialogLayout.getStyle().set("width", "600px").set("max-width", "100%");
+  public void setConfirmListener(ComponentEventListener<ClickEvent<Button>> confirmListener) {
+    this.confirmButton.addClickListener(confirmListener);
+  }
 
-        return dialogLayout;
-    }
+  public void setTitle(String title) {
+    this.title = title;
+    this.header
+        .getElement()
+        .getChildren()
+        .filter(element -> element.hasAttribute("title"))
+        .findFirst()
+        .ifPresent(
+            element -> {
+              element.setText(title);
+              element.setAttribute("title", title);
+            });
+  }
 
-    private HorizontalLayout buildHeaderLayout() {
-        H2 title = new H2(this.title);
-        title.setClassName("title");
-        title.getElement().setAttribute("title", this.title);
-        title.getStyle().set("margin", "-5px 0 0 15px")
-                .set("font-size", "22px").set("font-weight", "bold");
-        HorizontalLayout headerLayout = new HorizontalLayout(title);
-        headerLayout
-                .setJustifyContentMode(FlexComponent.JustifyContentMode.START);
-        return headerLayout;
-    }
+  public void setMessage(String message) {
+    this.message = message;
+    this.body
+        .getElement()
+        .getChildren()
+        .filter(element -> element.hasAttribute("message"))
+        .findFirst()
+        .ifPresent(
+            element -> {
+              element.setText(message);
+              element.setAttribute("message", message);
+            });
+  }
 
-    private HorizontalLayout buildFooterLayout(String... classNames) {
-        confirmButton = new Button("Confirm");
-        List<String> classButton = new ArrayList<>(List.of("control-button"));
-        if (classNames != null && classNames.length > 0) {
-            Arrays.stream(classNames).forEach(classButton::add);
-        } else {
-            classButton.add("green-button");
-        }
-        confirmButton.addClassNames(classButton.toArray(new String[0]));
-        Button cancelButton = new Button("Cancel", e -> this.close());
-        cancelButton.addClassNames("control-button", "blue-button");
+  public HorizontalLayout getHeader() {
+    return header;
+  }
 
-        HorizontalLayout footerLayout = new HorizontalLayout(confirmButton, cancelButton);
-        footerLayout
-                .setJustifyContentMode(FlexComponent.JustifyContentMode.END);
-        footerLayout.getStyle().set("margin", "20px 0 -15px 0");
-        return footerLayout;
-    }
+  public VerticalLayout getBody() {
+    return body;
+  }
 
-    private VerticalLayout buildBodyLayout() {
-        Span messageField = new Span(this.message);
-        messageField.getElement().setAttribute("message", message);
-        VerticalLayout bodyLayout = new VerticalLayout(messageField);
-        bodyLayout.setSpacing(false);
-        bodyLayout.setPadding(false);
-        bodyLayout.setAlignItems(FlexComponent.Alignment.STRETCH);
-        return bodyLayout;
-    }
-
-    public void setConfirmListener(ComponentEventListener<ClickEvent<Button>> confirmListener) {
-        this.confirmButton.addClickListener(confirmListener);
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-        this.header.getElement().getChildren().filter(element -> element.hasAttribute("title"))
-                .findFirst().ifPresent(element -> {
-                    element.setText(title);
-                    element.setAttribute("title", title);
-                });
-    }
-
-    public void setMessage(String message) {
-        this.message = message;
-        this.body.getElement().getChildren().filter(element -> element.hasAttribute("message"))
-                .findFirst().ifPresent(element -> {
-                    element.setText(message);
-                    element.setAttribute("message", message);
-                });
-    }
-
-    public HorizontalLayout getHeader() {
-        return header;
-    }
-
-    public VerticalLayout getBody() {
-        return body;
-    }
-
-    public HorizontalLayout getFooter() {
-        return footer;
-    }
+  public HorizontalLayout getFooter() {
+    return footer;
+  }
 }

--- a/src/main/java/io/awesome/ui/components/dialog/ConfirmDialog.java
+++ b/src/main/java/io/awesome/ui/components/dialog/ConfirmDialog.java
@@ -1,0 +1,125 @@
+package io.awesome.ui.components.dialog;
+
+import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.html.H2;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.FlexComponent;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class ConfirmDialog extends Dialog {
+
+    private String title = "";
+    private String message = "";
+    private HorizontalLayout header;
+    private VerticalLayout body;
+    private HorizontalLayout footer;
+    private Button confirmButton;
+
+    public ConfirmDialog(String... classNames) {
+        VerticalLayout dialogLayout = createDialogLayout(classNames);
+        this.add(dialogLayout);
+    }
+
+    public ConfirmDialog(String title, String message, String... classNames) {
+        this(classNames);
+        this.setTitle(title);
+        this.setMessage(message);
+    }
+
+    private VerticalLayout createDialogLayout(String... classNames) {
+        this.header = buildHeaderLayout();
+        this.body = buildBodyLayout();
+        this.footer = buildFooterLayout(classNames);
+
+        VerticalLayout dialogLayout = new VerticalLayout(header, body,
+                footer);
+        dialogLayout.setPadding(false);
+        dialogLayout.setAlignItems(FlexComponent.Alignment.STRETCH);
+        dialogLayout.getStyle().set("width", "600px").set("max-width", "100%");
+
+        return dialogLayout;
+    }
+
+    private HorizontalLayout buildHeaderLayout() {
+        H2 title = new H2(this.title);
+        title.setClassName("title");
+        title.getElement().setAttribute("title", this.title);
+        title.getStyle().set("margin", "-5px 0 0 15px")
+                .set("font-size", "22px").set("font-weight", "bold");
+        HorizontalLayout headerLayout = new HorizontalLayout(title);
+        headerLayout
+                .setJustifyContentMode(FlexComponent.JustifyContentMode.START);
+        return headerLayout;
+    }
+
+    private HorizontalLayout buildFooterLayout(String... classNames) {
+        confirmButton = new Button("Confirm");
+        List<String> classButton = new ArrayList<>(List.of("control-button"));
+        if (classNames != null && classNames.length > 0) {
+            Arrays.stream(classNames).forEach(classButton::add);
+        } else {
+            classButton.add("green-button");
+        }
+        confirmButton.addClassNames(classButton.toArray(new String[0]));
+        Button cancelButton = new Button("Cancel", e -> this.close());
+        cancelButton.addClassNames("control-button", "blue-button");
+
+        HorizontalLayout footerLayout = new HorizontalLayout(confirmButton, cancelButton);
+        footerLayout
+                .setJustifyContentMode(FlexComponent.JustifyContentMode.END);
+        footerLayout.getStyle().set("margin", "20px 0 -15px 0");
+        return footerLayout;
+    }
+
+    private VerticalLayout buildBodyLayout() {
+        Span messageField = new Span(this.message);
+        messageField.getElement().setAttribute("message", message);
+        VerticalLayout bodyLayout = new VerticalLayout(messageField);
+        bodyLayout.setSpacing(false);
+        bodyLayout.setPadding(false);
+        bodyLayout.setAlignItems(FlexComponent.Alignment.STRETCH);
+        return bodyLayout;
+    }
+
+    public void setConfirmListener(ComponentEventListener<ClickEvent<Button>> confirmListener) {
+        this.confirmButton.addClickListener(confirmListener);
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+        this.header.getElement().getChildren().filter(element -> element.hasAttribute("title"))
+                .findFirst().ifPresent(element -> {
+                    element.setText(title);
+                    element.setAttribute("title", title);
+                });
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+        this.body.getElement().getChildren().filter(element -> element.hasAttribute("message"))
+                .findFirst().ifPresent(element -> {
+                    element.setText(message);
+                    element.setAttribute("message", message);
+                });
+    }
+
+    public HorizontalLayout getHeader() {
+        return header;
+    }
+
+    public VerticalLayout getBody() {
+        return body;
+    }
+
+    public HorizontalLayout getFooter() {
+        return footer;
+    }
+}

--- a/src/main/java/io/awesome/ui/components/grid/column/Badge.java
+++ b/src/main/java/io/awesome/ui/components/grid/column/Badge.java
@@ -1,28 +1,27 @@
-package io.awesome.ui.components.common;
+package io.awesome.ui.components.grid.column;
 
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.FlexLayout;
 import io.awesome.enums.IAttributeEnum;
-import io.awesome.ui.components.Badge;
 import io.awesome.ui.components.FlexBoxLayout;
 import io.awesome.ui.util.UIUtil;
 import org.apache.commons.lang.StringUtils;
 
-public class EnumBadge extends FlexBoxLayout {
+public class Badge extends FlexBoxLayout {
 
-    public <X, T> EnumBadge(IAttributeEnum<X, T> attributeEnum) {
+    public <X, T> Badge(IAttributeEnum<X, T> attributeEnum) {
         super();
         this.setJustifyContentMode(FlexComponent.JustifyContentMode.START);
         this.setFlexWrap(FlexLayout.FlexWrap.WRAP);
         this.add(buildBadge(attributeEnum));
     }
 
-    private <X, T> Badge buildBadge(IAttributeEnum<X, T> attributeEnum) {
-        Badge badge;
+    private <X, T> io.awesome.ui.components.Badge buildBadge(IAttributeEnum<X, T> attributeEnum) {
+        io.awesome.ui.components.Badge badge;
         if (StringUtils.isNotBlank(attributeEnum.getLabel())) {
-            badge = new Badge(attributeEnum.getLabel());
+            badge = new io.awesome.ui.components.Badge(attributeEnum.getLabel());
         } else {
-            badge = new Badge(attributeEnum.getName());
+            badge = new io.awesome.ui.components.Badge(attributeEnum.getName());
         }
 
         if (StringUtils.isNotBlank(attributeEnum.getColor())) {

--- a/src/main/java/io/awesome/ui/components/grid/column/Checkbox.java
+++ b/src/main/java/io/awesome/ui/components/grid/column/Checkbox.java
@@ -1,0 +1,26 @@
+package io.awesome.ui.components.grid.column;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.icon.Icon;
+import com.vaadin.flow.component.icon.VaadinIcon;
+
+public class Checkbox extends Div {
+
+    public Checkbox(Boolean value) {
+        this.setWidthFull();
+        this.add(buildIcon(value));
+    }
+
+    private Icon buildIcon(Boolean value) {
+        Icon icon;
+        if (value.equals(Boolean.FALSE)) {
+            icon = new Icon(VaadinIcon.CLOSE_CIRCLE);
+            icon.setColor("red");
+        } else {
+            icon = new Icon(VaadinIcon.CHEVRON_CIRCLE_DOWN);
+            icon.setColor("green");
+        }
+        icon.setSize("15px");
+        return icon;
+    }
+}

--- a/src/main/java/io/awesome/ui/errors/CustomErrorHandler.java
+++ b/src/main/java/io/awesome/ui/errors/CustomErrorHandler.java
@@ -4,35 +4,31 @@ import com.google.common.base.Throwables;
 import com.vaadin.flow.server.ErrorEvent;
 import com.vaadin.flow.server.ErrorHandler;
 import io.awesome.util.NotificationUtil;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 public class CustomErrorHandler implements ErrorHandler {
-    private static final Logger log = LoggerFactory.getLogger(CustomErrorHandler.class);
-    @Override
-    public void error(ErrorEvent errorEvent) {
-        log.error("Uncaught UI exception", errorEvent.getThrowable());
-        NotificationUtil.error(
-                "We are sorry, but an internal error occurred: "
-                        + getMessage(errorEvent.getThrowable()));
-    }
+  private static final Logger log = LoggerFactory.getLogger(CustomErrorHandler.class);
 
-    private String getMessage(Throwable throwable) {
-        if (throwable.getCause() != null) {
-            Throwable nestedError = throwable.getCause();
-            if (nestedError instanceof DataAccessException) {
-                String rootMessage = Throwables.getRootCause(nestedError).getMessage();
-                if (rootMessage.contains("Detail: ")) {
-                    return rootMessage.substring(rootMessage.indexOf("Detail: "));
-                }
-                return rootMessage;
-            }
+  @Override
+  public void error(ErrorEvent errorEvent) {
+    log.error("Uncaught UI exception", errorEvent.getThrowable());
+    NotificationUtil.error(
+        "We are sorry, but an internal error occurred: " + getMessage(errorEvent.getThrowable()));
+  }
+
+  private String getMessage(Throwable throwable) {
+    if (throwable.getCause() != null) {
+      Throwable nestedError = throwable.getCause();
+      if (nestedError instanceof DataAccessException) {
+        String rootMessage = Throwables.getRootCause(nestedError).getMessage();
+        if (rootMessage.contains("Detail: ")) {
+          return rootMessage.substring(rootMessage.indexOf("Detail: "));
         }
-        return throwable.getMessage();
+        return rootMessage;
+      }
     }
+    return throwable.getMessage();
+  }
 }

--- a/src/main/java/io/awesome/ui/errors/CustomErrorHandler.java
+++ b/src/main/java/io/awesome/ui/errors/CustomErrorHandler.java
@@ -1,0 +1,38 @@
+package io.awesome.ui.errors;
+
+import com.google.common.base.Throwables;
+import com.vaadin.flow.server.ErrorEvent;
+import com.vaadin.flow.server.ErrorHandler;
+import io.awesome.util.NotificationUtil;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CustomErrorHandler implements ErrorHandler {
+    private static final Logger log = LoggerFactory.getLogger(CustomErrorHandler.class);
+    @Override
+    public void error(ErrorEvent errorEvent) {
+        log.error("Uncaught UI exception", errorEvent.getThrowable());
+        NotificationUtil.error(
+                "We are sorry, but an internal error occurred: "
+                        + getMessage(errorEvent.getThrowable()));
+    }
+
+    private String getMessage(Throwable throwable) {
+        if (throwable.getCause() != null) {
+            Throwable nestedError = throwable.getCause();
+            if (nestedError instanceof DataAccessException) {
+                String rootMessage = Throwables.getRootCause(nestedError).getMessage();
+                if (rootMessage.contains("Detail: ")) {
+                    return rootMessage.substring(rootMessage.indexOf("Detail: "));
+                }
+                return rootMessage;
+            }
+        }
+        return throwable.getMessage();
+    }
+}

--- a/src/main/java/io/awesome/ui/layout/SidebarLayout.java
+++ b/src/main/java/io/awesome/ui/layout/SidebarLayout.java
@@ -18,6 +18,7 @@ import io.awesome.ui.components.navigation.bar.AppBar;
 import io.awesome.ui.components.navigation.bar.TabBar;
 import io.awesome.ui.components.navigation.drawer.NaviDrawer;
 import io.awesome.ui.components.navigation.drawer.NaviItem;
+import io.awesome.ui.errors.CustomErrorHandler;
 import io.awesome.ui.util.UIUtil;
 import io.awesome.ui.util.css.Display;
 import io.awesome.ui.util.css.Overflow;
@@ -62,14 +63,7 @@ public abstract class SidebarLayout extends FlexBoxLayout
   @Autowired
   public SidebarLayout() {
     VaadinSession.getCurrent()
-        .setErrorHandler(
-            (ErrorHandler)
-                errorEvent -> {
-                  log.error("Uncaught UI exception", errorEvent.getThrowable());
-                  NotificationUtil.error(
-                      "We are sorry, but an internal error occurred: "
-                          + errorEvent.getThrowable().getMessage());
-                });
+        .setErrorHandler(new CustomErrorHandler());
 
     addClassName(CLASS_NAME);
     setFlexDirection(FlexDirection.COLUMN);

--- a/src/main/java/io/awesome/ui/views/CrudView.java
+++ b/src/main/java/io/awesome/ui/views/CrudView.java
@@ -252,7 +252,7 @@ public abstract class CrudView<F extends BaseFilterUI, L, E, M extends CrudMappe
   }
 
   protected List<Component> createContents() {
-    List<DataTable.Action<Set<L>>> actions = dataTableActions();
+    List<DataTable.Action<L>> actions = dataTableActions();
     this.dataTable =
         new DataTable<L>(listEntityClazz, getTableTitle(), this::getPagingData, actions);
     this.dataTable.setPageLimit(PAGE_LIMIT);
@@ -430,7 +430,7 @@ public abstract class CrudView<F extends BaseFilterUI, L, E, M extends CrudMappe
     this.dataTable.reload();
   }
 
-  protected List<DataTable.Action<Set<L>>> dataTableActions() {
+  protected List<DataTable.Action<L>> dataTableActions() {
     return Collections.emptyList();
   }
 

--- a/src/main/java/io/awesome/util/NotificationUtil.java
+++ b/src/main/java/io/awesome/util/NotificationUtil.java
@@ -14,7 +14,7 @@ public class NotificationUtil {
   }
 
   public static void error(String message) {
-    show(message, NotificationVariant.LUMO_ERROR);
+    show(message, 10000, Notification.Position.TOP_END, NotificationVariant.LUMO_ERROR);
   }
 
   public static void show(String message) {


### PR DESCRIPTION
- When datatable in multi mode, an item has to be selected before doing any action. It will be too annoying, if we need to edit the item. Therefore, we provide the way to define a column that clickable, so user can fire select an item event to open the edit box.
- Problem:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/3679360/178434749-7a8b854c-72cf-4c95-b818-baf1a13fc02b.png">
- Solved
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/3679360/178434878-8ddaabb0-d27c-4c23-a575-b8640e15fe0c.png">
